### PR TITLE
Feature/js message model updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+If this PR fixes a bug, you _must_ add test cases representative of the bug.
 #### What's this PR do?
 #### Related JIRA tickets:
 #### How should this be manually tested?

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-plugin-add-module-exports": "0.2.1",
     "babel-preset-es2015": "6.16.0",
     "babel-preset-stage-2": "6.18.0",
+    "chai-datetime": "1.5.0",
     "coveralls": "^2.11.6",
     "cross-env": "3.1.3",
     "eslint": "3.16.1",

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -10,6 +10,24 @@ module.exports = (sequelize, DataTypes) => {
             autoIncrement: true,
             primaryKey: true,
         },
+        /**
+         * Each sent message is replicated for every recipient. This allows
+         * users to maintain their own copies of a message for tracking
+         * readAt times and soft deletion. It also allows for per-user
+         * message threading.
+         */
+        owner: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        originalMessageId: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+        },
+        parentMessageId: {
+            type: DataTypes.INTEGER,
+            allowNull: true,
+        },
         /* eslint-disable new-cap */
         to: {
             type: DataTypes.ARRAY(DataTypes.STRING),

--- a/server/routes/index.route.js
+++ b/server/routes/index.route.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import messageRoutes from './message.route';
-import p from '../../package.json';
+import p from '../../package';
 
 const router = express.Router(); // eslint-disable-line new-cap
 const version = p.version.split('.').shift();

--- a/server/routes/index.route.js
+++ b/server/routes/index.route.js
@@ -1,7 +1,10 @@
 import express from 'express';
 import messageRoutes from './message.route';
+import p from '../../package.json';
 
 const router = express.Router(); // eslint-disable-line new-cap
+const version = p.version.split('.').shift();
+const baseURL = (version > 0 ? `/v${version}` : '');
 
 /** GET /health-check - Check service health */
 router.get('/health-check', (req, res) =>
@@ -9,6 +12,6 @@ router.get('/health-check', (req, res) =>
 );
 
 // mount message routes at /message
-router.use('/message', messageRoutes);
+router.use(`${baseURL}/message`, messageRoutes);
 
 export default router;

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -5,13 +5,17 @@ import request from 'supertest-as-promised';
 import httpStatus from 'http-status';
 import chai, { expect } from 'chai';
 import app from '../../index';
+import p from '../../package';
 import {
     Message,
     sequelize
 } from '../../config/sequelize';
 import _ from 'lodash';
 
-const baseURL = '/api/v1';
+chai.use(require('chai-datetime'));
+
+const version = p.version.split('.').shift();
+const baseURL = (version > 0 ? `/api/v${version}` : '/api');
 
 const testMessageObject = {
     to: ['user1'],
@@ -23,13 +27,13 @@ const testMessageObject = {
 describe('Message API:', function () {
 
     before(() => {
-        Message.sync({
+        return Message.sync({
             force: true
         });
     });
     
     after(() => {
-        Message.destroy({
+        return Message.destroy({
             where: {},
             truncate: true
         });
@@ -37,7 +41,7 @@ describe('Message API:', function () {
 
     describe('POST /message/send', function () {
 
-        xit('should return OK', done => {
+        it('should return OK', done => {
             request(app)
                 .post(baseURL + '/message/send')
                 .send(testMessageObject)
@@ -49,7 +53,12 @@ describe('Message API:', function () {
                 .catch(done);
         });
         
-        xit('should return the sent Message object', done => {
+        /**
+         * Every recipient, plus the sender, gets their own version
+         * of the message with the `owner` field set to their user ID.
+         * Creating a message should return the sender's version of the message.
+         */
+        it('should return the sender Message object', done => {
             request(app)
                 .post(baseURL + '/message/send')
                 .send(testMessageObject)
@@ -61,7 +70,7 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
-        xit('should create a new Message in the DB', done => {
+        it('should create new Messages in the DB', done => {
             request(app)
                 .post(baseURL + '/message/send')
                 .send(testMessageObject)
@@ -71,13 +80,17 @@ describe('Message API:', function () {
                     Message.findById(id)
                         .then(message => {
                             expect(message).to.deep.include(testMessageObject);
-                            done();
+                            Message.findOne({where: {owner: testMessageObject.to[0]}})
+                                .then(message => {
+                                    expect(message).to.deep.include(testMessageObject);
+                                    done();
+                                });
                         });
                 })
                 .catch(done);
         });
 
-        xit('should have a createdAt timestamp', done => {
+        it('returned message should have a createdAt timestamp', done => {
             request(app)
                 .post(baseURL + '/message/send')
                 .send(testMessageObject)
@@ -90,7 +103,7 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
-        xit('should have readAt set to NULL', done => {
+        it('recipient message should have readAt set to NULL', done => {
             request(app)
                 .post(baseURL + '/message/send')
                 .send(testMessageObject)
@@ -101,6 +114,56 @@ describe('Message API:', function () {
                 })
                 .catch(done);
         });
+
+        /**
+         * Sent messages are considered read
+         */
+        it('sender message should have readAt set to createdAt time', done => {
+            request(app)
+                .post(baseURL + '/message/send')
+                .send(testMessageObject)
+                .expect(httpStatus.OK)
+                .then(res => {
+                    Message.findOne({where: {owner: testMessageObject.to[0]}})
+                        .then(message => {
+                            expect(message.readAt).to.be.not.null;
+                            expect(message.readAt).to.equalDate(message.createdAt);
+                            done();
+                        });
+                })
+                .catch(done);
+        });
+
+    });
+
+    describe('POST /message/reply/:messageId', () => {
+
+        let messageId;
+        
+        before(done => {
+            Message.create(testMessageObject)
+                .then(message => {
+                    messageId = message.id;
+                    done();
+                });
+        });
+
+        it('should return OK', done => {
+            request(app)
+                .post(baseURL + '/message/send')
+                .send(testMessageObject)
+                .expect(httpStatus.OK)
+                .then(res => {
+                    expect(res.text).to.equal('OK');
+                    done();
+                })
+                .catch(done);
+        });
+
+        // TODO leaving these for Jacob to work on
+        it('should return the response message owned by the sender');
+
+        it('should create new messages in the DB with appropriate threaded message IDs');
 
     });
 
@@ -116,7 +179,7 @@ describe('Message API:', function () {
                 });
         });
 
-        xit('should return OK', done => {
+        it('should return OK', done => {
             request(app)
                 .get(baseURL + '/message/list' + userId)
                 .expect(httpStatus.OK)
@@ -127,7 +190,7 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
-        xit('should return all Message addressed to a user', done => {
+        it('should return all Message addressed to a user', done => {
             request(app)
                 .get(baseURL + '/message/list' + userId)
                 .expect(httpStatus.OK)
@@ -140,10 +203,13 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
+        // TODO: Ruchita to write this test
         it('has an option to limit Message returned');
 
+        // TODO: Ruchita to write this test
         it('has an option to limit by sender');
 
+        // TODO: Ruchita to write this test
         it('has an option to return summaries');
 
     });
@@ -165,7 +231,7 @@ describe('Message API:', function () {
             });
         });
 
-        xit('should return OK', done => {
+        it('should return OK', done => {
             request(app)
                 .get(baseURL + '/message/count' + userId)
                 .expect(httpStatus.OK)
@@ -176,7 +242,7 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
-        xit('should return a count for total Message', done => {
+        it('should return a count for total Messages', done => {
             request(app)
                 .get(baseURL + '/message/count' + userId)
                 .expect(httpStatus.OK)
@@ -187,7 +253,7 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
-        xit('should return a count for unread Message', done => {
+        it('should return a count for unread Messages', done => {
             request(app)
                 .get(baseURL + '/message/count' + userId)
                 .expect(httpStatus.OK)
@@ -212,7 +278,7 @@ describe('Message API:', function () {
                 });
         });
 
-        xit('should return OK', done => {
+        it('should return OK', done => {
             request(app)
                 .get(baseURL + '/message/get' + messageId)
                 .expect(httpStatus.OK)
@@ -223,7 +289,7 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
-        xit('should return the specified Message', done => {
+        it('should return the specified Message', done => {
             request(app)
                 .get(baseURL + '/message/get' + messageId)
                 .expect(httpStatus.OK)
@@ -234,13 +300,53 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
-        xit('should mark the Message retrieved as read', done => {
+        it('should mark the Message retrieved as read', done => {
             request(app)
                 .get(baseURL + '/message/get' + messageId)
                 .expect(httpStatus.OK)
                 .then(res => {
                     expect(res.body.readAt).to.not.be.null;
                     expect(res.body.readAt).to.be.a('Date');
+                    done();
+                })
+                .catch(done);
+        });
+
+    });
+
+    // TODO: this one is going to be hard
+    describe('GET /message/thread/:originalMessageId', () => {
+        
+        let messageId;
+        
+        before(done => {
+            Message.create(testMessageObject)
+                .then(message => {
+                    originalMessageId = message.originalMessageId;
+                    done();
+                });
+        });
+
+        // TODO: create a real response message here
+
+        it('should return OK', done => {
+            request(app)
+                .get(baseURL + '/message/thread' + originalMessageId)
+                .expect(httpStatus.OK)
+                .then(res => {
+                    expect(res.text).to.equal('OK');
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should return an array of message IDs, starting with the original message', done => {
+            request(app)
+                .get(baseURL + '/message/thread' + originalMessageId)
+                .expect(httpStatus.OK)
+                .then(res => {
+                    expect(res.body).to.be.an.array;
+                    // TODO check specific IDs
                     done();
                 })
                 .catch(done);

--- a/server/tests/message.model.spec.js
+++ b/server/tests/message.model.spec.js
@@ -1,0 +1,74 @@
+
+/* eslint-disable */
+
+import chai, { expect } from 'chai';
+import app from '../../index';
+import {
+    Message,
+    sequelize
+} from '../../config/sequelize';
+import _ from 'lodash';
+
+chai.use(require('chai-datetime'));
+
+const testMessageObject = {
+    owner: 'user1',
+    to: ['user1'],
+    from: 'user0',
+    subject: 'Test Message',
+    message: 'Test post please ignore',
+    createdAt: new Date(),
+};
+
+describe('Message Model:', () => {
+
+    before(() => {
+        return Message.sync({
+            force: true
+        });
+    });
+    
+    after(() => {
+        return Message.destroy({
+            where: {},
+            truncate: true
+        });
+    });
+
+    describe('Object creation', () => {
+
+        it('Create Message', done => {
+            Message
+                .create(testMessageObject)
+                .then(message => {
+                    expect(message).to.exist;
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('Verify message', done => {
+            Message
+                .create(testMessageObject)
+                .then(message => {
+                    Message
+                        .findById(message.id)
+                        .then(message => {
+                            expect(message.owner).to.equal(testMessageObject.owner);
+                            expect(message.originalMessageId).to.be.null;
+                            expect(message.parentMessageId).to.be.null;
+                            expect(message.to).to.deep.equal(testMessageObject.to);
+                            expect(message.from).to.equal(testMessageObject.from);
+                            expect(message.subject).to.equal(testMessageObject.subject);
+                            expect(message.message).to.equal(testMessageObject.message);
+                            expect(message.createdAt).to.equalDate(testMessageObject.createdAt);
+                            expect(message.readAt).to.be.null;
+                            done();
+                        });
+                })
+                .catch(done);
+        });
+
+    });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,12 +900,6 @@ bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
-cachedir@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-1.1.1.tgz#e1363075ea206a12767d92bb711c8a2f76a10f62"
-  dependencies:
-    os-homedir "^1.0.1"
-
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -939,7 +933,13 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai@^3.4.1:
+chai-datetime@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/chai-datetime/-/chai-datetime-1.5.0.tgz#3742f18b024c75b76a2b7eee291662324467596c"
+  dependencies:
+    chai ">1.9.0"
+
+chai@>1.9.0, chai@^3.4.1:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
   dependencies:
@@ -947,7 +947,7 @@ chai@^3.4.1:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@*, chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@*, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1030,10 +1030,6 @@ colors@1.0.x, colors@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-colors@~0.6.0-1:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
-
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -1045,30 +1041,6 @@ commander@2.9.0, commander@^2.8.1, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
-
-commander@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
-
-commitizen@^2.9.2:
-  version "2.9.6"
-  resolved "https://registry.yarnpkg.com/commitizen/-/commitizen-2.9.6.tgz#c0d00535ef264da7f63737edfda4228983fa2291"
-  dependencies:
-    cachedir "^1.1.0"
-    chalk "1.1.3"
-    cz-conventional-changelog "1.2.0"
-    dedent "0.6.0"
-    detect-indent "4.0.0"
-    find-node-modules "1.0.4"
-    find-root "1.0.0"
-    fs-extra "^1.0.0"
-    glob "7.1.1"
-    inquirer "1.2.3"
-    lodash "4.17.2"
-    minimist "1.2.0"
-    path-exists "2.1.0"
-    shelljs "0.7.6"
-    strip-json-comments "2.0.1"
 
 component-emitter@^1.2.0:
   version "1.2.1"
@@ -1095,7 +1067,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.4.7:
+concat-stream@^1.4.6:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1146,10 +1118,6 @@ content-security-policy-builder@1.1.0:
 content-type@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
-
-conventional-commit-types@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-commit-types/-/conventional-commit-types-2.1.0.tgz#45d860386c9a2e6537ee91d8a1b61bd0411b3d04"
 
 convert-source-map@1.X, convert-source-map@^1.1.0:
   version "1.5.0"
@@ -1230,17 +1198,6 @@ cycle@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
 
-cz-conventional-changelog@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/cz-conventional-changelog/-/cz-conventional-changelog-1.2.0.tgz#2bca04964c8919b23f3fd6a89ef5e6008b31b3f8"
-  dependencies:
-    conventional-commit-types "^2.0.0"
-    lodash.map "^4.5.1"
-    longest "^1.0.1"
-    pad-right "^0.2.2"
-    right-pad "^1.0.1"
-    word-wrap "^1.0.3"
-
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1288,10 +1245,6 @@ debug@2.6.3, debug@2.X, debug@^2.1.1, debug@^2.2.0, debug@^2.4.5:
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-
-dedent@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.6.0.tgz#0e6da8f0ce52838ef5cec5c8f9396b0c1b64a3cb"
 
 deep-eql@^0.1.3:
   version "0.1.3"
@@ -1357,7 +1310,7 @@ detect-file@^0.1.0:
   dependencies:
     fs-exists-sync "^0.1.0"
 
-detect-indent@4.0.0, detect-indent@^4.0.0:
+detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
   dependencies:
@@ -1743,14 +1696,6 @@ extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
-external-editor@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
-  dependencies:
-    extend "^3.0.0"
-    spawn-sync "^1.0.15"
-    tmp "^0.0.29"
-
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -1834,20 +1779,9 @@ find-index@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
 
-find-node-modules@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/find-node-modules/-/find-node-modules-1.0.4.tgz#b6deb3cccb699c87037677bcede2c5f5862b2550"
-  dependencies:
-    findup-sync "0.4.2"
-    merge "^1.2.0"
-
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
-
-find-root@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -1855,15 +1789,6 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
-
-findup-sync@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.2.tgz#a8117d0f73124f5a4546839579fe52d7129fb5e5"
-  dependencies:
-    detect-file "^0.1.0"
-    is-glob "^2.0.1"
-    micromatch "^2.3.7"
-    resolve-dir "^0.1.0"
 
 findup-sync@^0.4.0, findup-sync@^0.4.2:
   version "0.4.3"
@@ -1873,13 +1798,6 @@ findup-sync@^0.4.0, findup-sync@^0.4.2:
     is-glob "^2.0.1"
     micromatch "^2.3.7"
     resolve-dir "^0.1.0"
-
-findup@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/findup/-/findup-0.1.5.tgz#8ad929a3393bac627957a7e5de4623b06b0e2ceb"
-  dependencies:
-    colors "~0.6.0-1"
-    commander "~2.1.0"
 
 fined@^1.0.1:
   version "1.0.2"
@@ -1963,14 +1881,6 @@ from@~0:
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
-
-fs-extra@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    klaw "^1.0.0"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -2098,17 +2008,6 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^4.3.1:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
@@ -2125,6 +2024,17 @@ glob@^5.0.5:
     inflight "^1.0.4"
     inherits "2"
     minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2196,7 +2106,7 @@ got@^3.2.0:
     read-all-stream "^3.0.0"
     timed-out "^2.0.0"
 
-graceful-fs@4.X, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@4.X, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2528,25 +2438,6 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-inquirer@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-1.2.3.tgz#4dec6f32f37ef7bb0b2ed3f1d1a5c3f545074918"
-  dependencies:
-    ansi-escapes "^1.1.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
-    cli-width "^2.0.0"
-    external-editor "^1.1.0"
-    figures "^1.3.5"
-    lodash "^4.3.0"
-    mute-stream "0.0.6"
-    pinkie-promise "^2.0.0"
-    run-async "^2.2.0"
-    rx "^4.1.0"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
-    through "^2.3.6"
-
 inquirer@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
@@ -2684,10 +2575,6 @@ is-posix-bracket@^0.1.0:
 is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
-
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
 is-property@^1.0.0:
   version "1.0.2"
@@ -2916,12 +2803,6 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -2988,12 +2869,6 @@ kind-of@^3.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
   dependencies:
     is-buffer "^1.0.2"
-
-klaw@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
-  optionalDependencies:
-    graceful-fs "^4.1.9"
 
 latest-version@^1.0.0:
   version "1.0.1"
@@ -3170,10 +3045,6 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.map@^4.5.1:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
-
 lodash.mapvalues@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
@@ -3222,10 +3093,6 @@ lodash.templatesettings@^3.0.0:
 lodash@4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.12.0.tgz#2bd6dc46a040f59e686c972ed21d93dc59053258"
-
-lodash@4.17.2:
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
 lodash@4.17.4, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.9.0:
   version "4.17.4"
@@ -3283,10 +3150,6 @@ media-typer@0.3.0:
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-
-merge@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
 method-override@^2.3.5:
   version "2.3.8"
@@ -3419,10 +3282,6 @@ multipipe@^0.1.2:
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
-
-mute-stream@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
 
 nan@^2.3.0:
   version "2.6.1"
@@ -3604,11 +3463,7 @@ os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -3638,12 +3493,6 @@ packet-reader@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-0.2.0.tgz#819df4d010b82d5ea5671f8a1a3acf039bcd7700"
 
-pad-right@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/pad-right/-/pad-right-0.2.2.tgz#6fbc924045d244f2a2a244503060d3bfc6009774"
-  dependencies:
-    repeat-string "^1.5.2"
-
 parse-filepath@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.1.tgz#159d6155d43904d16c10ef698911da1e91969b73"
@@ -3669,7 +3518,7 @@ parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
 
-path-exists@2.1.0, path-exists@^2.0.0:
+path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   dependencies:
@@ -3857,11 +3706,11 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-qs@6.2.0:
+qs@6.2.0, qs@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
 
-qs@^6.1.0, qs@~6.3.0:
+qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
 
@@ -4137,10 +3986,6 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-right-pad@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/right-pad/-/right-pad-1.0.1.tgz#8ca08c2cbb5b55e74dafa96bf7fd1a27d568c8d0"
-
 rimraf@2, rimraf@^2.2.8, rimraf@^2.4.4, rimraf@^2.5.1, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
@@ -4153,12 +3998,6 @@ run-async@^0.1.0:
   dependencies:
     once "^1.3.0"
 
-run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
-  dependencies:
-    is-promise "^2.1.0"
-
 run-sequence@^1.1.5:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/run-sequence/-/run-sequence-1.2.2.tgz#5095a0bebe98733b0140bd08dd80ec030ddacdeb"
@@ -4170,10 +4009,6 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rx@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
-
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -4183,10 +4018,6 @@ semver-diff@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
   dependencies:
     semver "^5.0.3"
-
-semver-regex@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
 
 semver@4.3.2, semver@^4.1.0:
   version "4.3.2"
@@ -4278,7 +4109,7 @@ setprototypeof@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.2.tgz#81a552141ec104b88e89ce383103ad5c66564d08"
 
-shelljs@0.7.6, shelljs@^0.7.5:
+shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
   dependencies:
@@ -4354,13 +4185,6 @@ source-map@^0.4.4:
 sparkles@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3"
-
-spawn-sync@^1.0.15:
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
 
 split@0.3:
   version "0.3.3"
@@ -4477,7 +4301,7 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -4597,12 +4421,6 @@ time-stamp@^1.0.0:
 timed-out@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-2.0.0.tgz#f38b0ae81d3747d628001f41dafc652ace671c0a"
-
-tmp@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
-  dependencies:
-    os-tmpdir "~1.0.1"
 
 to-fast-properties@^1.0.1:
   version "1.0.2"
@@ -4768,15 +4586,6 @@ v8flags@^2.0.10, v8flags@^2.0.2:
   dependencies:
     user-home "^1.1.1"
 
-validate-commit-msg@^2.6.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/validate-commit-msg/-/validate-commit-msg-2.12.1.tgz#612b61bc9f09f0fee5130de3648870d01cdddf1d"
-  dependencies:
-    conventional-commit-types "^2.0.0"
-    find-parent-dir "^0.3.0"
-    findup "0.1.5"
-    semver-regex "1.0.0"
-
 validator@^5.2.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-5.7.0.tgz#7a87a58146b695ac486071141c0c49d67da05e5c"
@@ -4863,10 +4672,6 @@ winston@2.3.0:
 wkx@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/wkx/-/wkx-0.2.0.tgz#76c24f16acd0cd8f93cd34aa331e0f7961256e84"
-
-word-wrap@^1.0.3:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.1.tgz#248f459b465d179a17bc407c854d3151d07e45d8"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
#### What's this PR do?
- Updates the Message model with changes discussed in the design doc. These changes are enforced via the model.spec.
- Updates the API integration tests with API spec changes discussed in the design doc.
- Adds Node package versioning. Until major release 1, there will be no `vX` in the API path. After the first major release, the API path will begin `/api/vX`, where X is the major release version.
#### Related JIRA tickets:
SER-34, although it is already closed.
#### How should this be manually tested?
These tests should be failing, as the next step is TDD.
#### Any background context you want to provide?
There are some `TODO`s in here for tasks that @jsachs will work on soon.
#### Screenshots (if appropriate):