### PR TITLE
Add support for building AMI with packer

### DIFF
--- a/deploy/roles/api/tasks/main.yml
+++ b/deploy/roles/api/tasks/main.yml
@@ -3,10 +3,11 @@
   file: path={{ src_dir }} state=directory
 
 - name: Move API code to correct location
-  command: mv /tmp/dist {{ src_dir }}
+  command: mv /tmp/app {{ src_dir }}
 
-- name: Install api npm packages
-  command: chdir={{ src_dir }}/dist npm install -s
+- name: Install yarn
+  sudo: yes
+  command: npm install -g yarn
 
 - name: Copy systemd service
   sudo: yes
@@ -14,6 +15,14 @@
     src: express.service.j2
     dest: /etc/systemd/system/express.service
 
-- name: Enable api service
+- name: Copy env file
+  template:
+    src: env.service.j2
+    dest: /home/centos/api/app/.env
+
+- name: Install api npm packages
+  command: chdir={{ src_dir }}/app /.nvm/versions/node/v{{ node_version }}/lib/node_modules/yarn/bin/yarn
+
+- name: Start application with yarn in express service
   sudo: yes
   service: name=express state=started enabled=yes

--- a/deploy/roles/api/templates/env.service.j2
+++ b/deploy/roles/api/templates/env.service.j2
@@ -1,0 +1,8 @@
+NODE_ENV={{ node_env }}
+PORT={{ port }}
+JWT_SECRET={{ jwt_secret }}
+PG_DB={{ pg_db }}
+PG_PORT=5432
+PG_HOST={{ pg_host }}
+PG_USER={{ pg_user }}
+PG_PASSWD={{ pg_passwd }}

--- a/deploy/roles/api/templates/express.service.j2
+++ b/deploy/roles/api/templates/express.service.j2
@@ -3,8 +3,8 @@ Description=Express
 
 [Service]
 # Start the js-file starting the express server
-ExecStart={{ src_dir }}/dist/node_modules/.bin/gulp serve
-WorkingDirectory={{ src_dir }}/dist
+ExecStart=/.nvm/versions/node/v{{ node_version }}/lib/node_modules/yarn/bin/yarn start
+WorkingDirectory={{ src_dir }}/app
 Restart=always
 RestartSec=10
 StandardOutput=syslog

--- a/template.json
+++ b/template.json
@@ -22,9 +22,50 @@
     "security_group_id": "sg-dff3bcb9"
   }],
   "provisioners": [{
+    "type": "shell",
+    "inline": [
+      "mkdir /tmp/app"
+    ]
+  },{
     "type": "file",
-    "source": "./dist",
-    "destination": "/tmp"
+    "source": "./config",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./deploy",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./server",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./gulpfile.babel.js",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./.istanbul.yml",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./.snyk",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./.yarnrc",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./index.js",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./package.json",
+    "destination": "/tmp/app/"
+  },{
+    "type": "file",
+    "source": "./yarn.lock",
+    "destination": "/tmp/app/"
   },{
     "type": "shell",
     "inline": [
@@ -43,6 +84,6 @@
       "./deploy/roles/logging",
       "./deploy/roles/nginx"
     ],
-    "extra_arguments": "-vv --extra-vars \"db_host={{user `rds_host`}} db_password={{user `rds_password`}} node_env={{user `build_env`}}\""
+    "extra_arguments": "-vv --extra-vars \"pg_db={{user `pg_db`}} pg_host={{user `pg_host`}} pg_passwd={{user `pg_passwd`}} pg_user={{user `pg_user`}} node_env={{user `build_env`}} port={{user `port`}} jwt_secret={{user `jwt_secret`}}\""
   }]
 }


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

#### What's this PR do?
It add's support for building AMIs with Packer

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/DEVOPS-111

#### How should this be manually tested?
Install packer locally, build and launch the image with a command similar to:
packer build -var 'aws_access_key=myAWSAcessKey' \
    -var 'aws_secret_key=myAWSSecretKey' \
    -var 'build_env=development' \
    -var 'ami_name=amida_messaging_service' \
    -var 'node_env=development' \
    -var 'ami_name=amida_messaging_service' \
    -var 'jwt_secret=My-JWT-Token' \
    -var 'pg_host=amid-messages-packer-test.some_rand_string.us-west-2.rds.amazonaws.com' \
    -var 'pg_db=amida_messages' \
    -var 'pg_user=amida_messages' \
    -var 'pg_passwd=amida-messages' template.json

Launch an EC2 instance with the built image and visit the health-check endpoint at <host_address>:4000/api/health-check. Be sure to launch the instance with security groups that allow http access on the app port (currently 4000) and access from Postgres port on the data base. You should see an "OK" response.

#### Any background context you want to provide?

#### Screenshots (if appropriate):