### PR TITLE
add controller helper to check that JWT and `from` match

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -14,17 +14,3 @@ const opts = {
 module.exports = (passport) => {
     passport.use(new JwtStrategy(opts, (jwtPayload, done) => done(null, jwtPayload)));
 };
-
-// module.exports = () => {
-//     const jwtLogin = new JwtStrategy(jwtOptions, (req, payload, done) => {
-//         console.log(payload);
-//         done(null, payload);
-//     });
-//     passport.use(jwtLogin);
-//     return {
-//         initialize() {
-//             return passport.initialize();
-//         },
-//         authenticate: passport.authenticate('jwt', { session: false }),
-//     };
-// };

--- a/config/winston.js
+++ b/config/winston.js
@@ -7,8 +7,8 @@ const logger = new (winston.Logger)({
             colorize: true,
         }),
         new winston.transports.File({
-          filename: 'combined.log',
-          level: 'info'
+            filename: 'combined.log',
+            level: 'info',
         }),
     ],
 });

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -23,6 +23,18 @@ function load(req, res, next, id) {
 }
 
 /**
+ * Checks that the user authenticated with JWT is in the `from`
+ * field of the message (for send or reply).
+ */
+function checkFromUser(req, res, next) {
+    if (req.user.username !== req.body.from) {
+        const err = new APIError('Authenticated user must match `from` field in message', httpStatus.FORBIDDEN, true);
+        return next(err);
+    }
+    return next();
+}
+
+/**
  * Get message
  * @returns {Message}
  */
@@ -205,4 +217,4 @@ function archive(req, res) {
     return res.send(req.message);
 }
 
-export default { send, reply, get, list, count, remove, load, archive };
+export default { send, reply, get, list, count, remove, load, archive, checkFromUser };

--- a/server/routes/message.route.js
+++ b/server/routes/message.route.js
@@ -9,10 +9,14 @@ const router = express.Router(); // eslint-disable-line new-cap
 router.use(passport.authenticate('jwt', { session: false }));
 
 router.route('/send')
-    .post(validate(paramValidation.sendMessage), messageCtrl.send);
+    .post(validate(paramValidation.sendMessage),
+          messageCtrl.checkFromUser,
+          messageCtrl.send);
 
 router.route('/reply/:messageId')
-    .post(validate(paramValidation.replyMessage), messageCtrl.reply);
+    .post(validate(paramValidation.replyMessage),
+          messageCtrl.checkFromUser,
+          messageCtrl.reply);
 
 /**
  * url params:

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -137,6 +137,15 @@ describe('Message API:', function () {
                 .catch(done);
         });
 
+        it('sender must match JWT user', () => {
+            let newTestMessageObject = { ...testMessageObject, from: 'fakeUser' };
+            return request(app)
+                .post(baseURL + '/message/send')
+                .set('Authorization', `Bearer ${auth}`)
+                .send(newTestMessageObject)
+                .expect(httpStatus.FORBIDDEN)
+        });
+
         /**
          * Sent messages are considered read
          */
@@ -257,6 +266,15 @@ describe('Message API:', function () {
                 });
             })
         );
+
+        it('sender must match JWT user', () => {
+            let newReplyMessageObject = { ...goodReplyMessageObject, from: 'fakeUser' };
+            return request(app)
+                .post(`${baseURL}/message/reply/${messageId}`)
+                .set('Authorization', `Bearer ${auth2}`)
+                .send(newReplyMessageObject)
+                .expect(httpStatus.FORBIDDEN)
+        });
 
         it('should return an error if the messageId does not exist', () => request(app)
             .post(`${baseURL}/message/reply/99999`)


### PR DESCRIPTION
#### What's this PR do?
Enforce match between authenticated user sending a message and the user in the `from` field in a message object.

#### Related JIRA tickets:
SER-104

#### How should this be manually tested?
Run the test harness. If you are using your own version of the service to create messages via a REST client, check that the service rejects sent messages with a bogus `from` user.
