### PR TITLE
Allow logging parameters to be configured as user vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Be sure to have your postgres host running and replace the `pg_host` value in th
 1. First validate the AMI with a command similar to ```packer validate -var 'aws_access_key=myAWSAcessKey'
 -var 'aws_secret_key=myAWSSecretKey'
 -var 'build_env=development'
+-var 'logstash_host=logstash.amida.com'
+-var 'service_name=amida_messaging_microservice'
 -var 'ami_name=api-messaging-service-boilerplate'
 -var 'node_env=development'
 -var 'jwt_secret=My-JWT-Token'

--- a/deploy/roles/logging/templates/filebeat.yml
+++ b/deploy/roles/logging/templates/filebeat.yml
@@ -14,7 +14,7 @@ filebeat.prospectors:
 
 - input_type: log
   close_inactive: 8760h
-  document_type: api
+  document_type: {{ service_name }}_api
   paths:
     - /home/centos/api/app/*.log
 

--- a/deploy/roles/logging/vars/main.yml
+++ b/deploy/roles/logging/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 logstash_host: logstash.amida.com
-service_name: amida-messaging-microservice
+service_name: amida_messaging_microservice

--- a/template.json
+++ b/template.json
@@ -91,6 +91,6 @@
       "./deploy/roles/cron",
       "./deploy/roles/nginx"
     ],
-    "extra_arguments": "-vv --extra-vars \"pg_db={{user `pg_db`}} pg_host={{user `pg_host`}} pg_passwd={{user `pg_passwd`}} pg_user={{user `pg_user`}} node_env={{user `build_env`}} port={{user `port`}} jwt_secret={{user `jwt_secret`}}\""
+    "extra_arguments": "-vv --extra-vars \"pg_db={{user `pg_db`}} pg_host={{user `pg_host`}} pg_passwd={{user `pg_passwd`}} pg_user={{user `pg_user`}} node_env={{user `build_env`}} port={{user `port`}} jwt_secret={{user `jwt_secret`}} service_name={{user `service_name`}} logstash_host={{user `logstash_host`}}\""
   }]
 }


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
It allows the user to configure parameters for `logstash_host` and `service_name` when building the AMI. The user entered service name can also be used when querying logs on the logstash host
#### Related JIRA tickets:
#### How should this be manually tested?
#### Any background context you want to provide?
#### Screenshots (if appropriate):