### PR TITLE
from field populated by JWT, but archive test is failing

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -5,7 +5,6 @@ export default {
     sendMessage: {
         body: {
             to: Joi.array().items(Joi.string()).required(),
-            from: Joi.string().required(),
             subject: Joi.string().required(),
             message: Joi.string().required(),
         },
@@ -13,7 +12,6 @@ export default {
     replyMessage: {
         body: {
             to: Joi.array().items(Joi.string()).required(),
-            from: Joi.string().required(),
             subject: Joi.string().required(),
             message: Joi.string().required(),
         },

--- a/docs/src/messages.md
+++ b/docs/src/messages.md
@@ -19,7 +19,6 @@ Send a message to any number of recipients.
 
             {
                 to: ["johnDoe", "janeDoe"]
-                from: "johnJane",
                 subject: "This API Rocks!",
                 message: "This message is longer than it appears...",
             }
@@ -107,7 +106,6 @@ Reply to an existing message.
 
             {
                 to: ["johnDoe", "janeDoe"]
-                from: "johnJane",
                 subject: "This API Rocks!",
                 message: "This message is longer than it appears...",
             }

--- a/server/routes/message.route.js
+++ b/server/routes/message.route.js
@@ -9,14 +9,10 @@ const router = express.Router(); // eslint-disable-line new-cap
 router.use(passport.authenticate('jwt', { session: false }));
 
 router.route('/send')
-    .post(validate(paramValidation.sendMessage),
-          messageCtrl.checkFromUser,
-          messageCtrl.send);
+    .post(validate(paramValidation.sendMessage), messageCtrl.send);
 
 router.route('/reply/:messageId')
-    .post(validate(paramValidation.replyMessage),
-          messageCtrl.checkFromUser,
-          messageCtrl.reply);
+    .post(validate(paramValidation.replyMessage), messageCtrl.reply);
 
 /**
  * url params:

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -604,11 +604,11 @@ describe('Message API:', function () {
             .then(res => {
                 expect(res.body).to.deep.include(testMessageObject);
                 let id = res.body.id;
-                return Message
-                    .findById(id)
-                    .then(message => expect(message.isArchived).to.equal(false));
+                return MessageUnscoped
+                        .findById(id)
+                        .then(message => expect(message.isArchived).to.equal(false));
             })
-        );  
+        );
 
         after(() => Message
             .destroy({


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
The `from` field is no longer required when sending a message in the request body. This will always be populated by the JWT.
#### Related JIRA tickets:
https://jira.amida-tech.com/browse/SER-127
#### How should this be manually tested?
Test harness, plus existing message workflows should function exactly as they did before.
#### Any background context you want to provide?
Note for @ElijahGeorge: the unarchiving test appears to break in this PR and I'm not sure why.