### PR TITLE
Adding extra query params for message list

### DIFF
--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -183,11 +183,11 @@ function list(req, res) {
     }
 
     if (req.query.received) {
-        queryObject.where.to = { $contains: req.user.userName };
+        queryObject.where.to = { $contains: [req.user.username] };
     }
 
     if (req.query.sent) {
-        queryObject.where.from = req.user.userName;
+        queryObject.where.from = req.user.username;
     }
 
     if (req.query.unread) {

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -174,8 +174,24 @@ function list(req, res) {
         queryObject.limit = req.query.limit;
     }
 
+    if (req.query.offset) {
+        queryObject.offset = req.query.offset;
+    }
+
     if (req.query.summary) {
         queryObject.attributes = ['subject', 'from', 'createdAt'];
+    }
+
+    if (req.query.recieved) {
+        queryObject.where.to = { $contains: req.user.userName };
+    }
+
+    if (req.query.sent) {
+        queryObject.where.from = req.user.userName;
+    }
+
+    if (req.query.unread) {
+        queryObject.where.readAt = null;
     }
 
     if (req.query.archived && req.query.archived === 'true') {

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -182,7 +182,7 @@ function list(req, res) {
         queryObject.attributes = ['subject', 'from', 'createdAt'];
     }
 
-    if (req.query.recieved) {
+    if (req.query.received) {
         queryObject.where.to = { $contains: req.user.userName };
     }
 

--- a/server/routes/message.route.js
+++ b/server/routes/message.route.js
@@ -19,6 +19,10 @@ router.route('/reply/:messageId')
  * - limit: number of messages to return
  * - from: filter on message sender by username
  * - summary: boolean, can return a summary version of messages
+ * - received: boolean, filters by recieved messages
+ * - sent: boolean, filters by send messages
+ * - unread: boolean, filters by unread messages
+ * - offset: int, to be used with limit for pagination
  */
 router.route('/list')
     .get(messageCtrl.list);

--- a/server/routes/message.route.js
+++ b/server/routes/message.route.js
@@ -19,7 +19,7 @@ router.route('/reply/:messageId')
  * - limit: number of messages to return
  * - from: filter on message sender by username
  * - summary: boolean, can return a summary version of messages
- * - received: boolean, filters by recieved messages
+ * - received: boolean, filters by received messages
  * - sent: boolean, filters by send messages
  * - unread: boolean, filters by unread messages
  * - offset: int, to be used with limit for pagination

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -318,6 +318,17 @@ describe('Message API:', () => {
             })
         );
 
+        it('has an option to offset Messages returned', () => request(app)
+            .get(`${baseURL}/message/list?offset=${testMessageArray.length - 1}`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(res.body.length).to.be.at.most(1);
+                return;
+            })
+        );
+
         it('has an option to limit by sender', () => request(app)
             .get(`${baseURL}/message/list?from=${userName}`)
             .set('Authorization', `Bearer ${auth}`)
@@ -326,6 +337,60 @@ describe('Message API:', () => {
                 expect(res.body).to.be.an('array');
                 expect(res.body[0].from).to.equal(testMessageArray[0].from);
                 expect(res.body[0].to).to.deep.equal(testMessageArray[0].to);
+                return;
+            })
+        );
+
+        it('has an option to filter by sent messages', () => request(app)
+            .get(`${baseURL}/message/list?sent=true`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(() => {
+                    let i;
+                    for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus
+                        if (res.body[i].from !== userName) {
+                            throw new Error(`${res.body[i].from} does not equal ${userName}`);
+                        }
+                    }
+                }).to.not.throw();
+                return;
+            })
+        );
+
+        it('has an option to filter by recieved messages', () => request(app)
+            .get(`${baseURL}/message/list?recieved=true`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(() => {
+                    let i;
+                    for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus
+                        if (!res.body[i].to.includes(userName)) {
+                            throw new Error(`${res.body[i].to} does not contain ${userName}`);
+                        }
+                    }
+                }).to.not.throw();
+                return;
+            })
+        );
+
+        it('has an option to filter by unread messages', () => request(app)
+            .get(`${baseURL}/message/list?unread=true`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(() => {
+                    let i;
+                    for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus
+                        if (res.body[i].readAt) {
+                            throw new Error(`${res.body[i].readAt} message was already read`);
+                        }
+                    }
+                }).to.not.throw();
                 return;
             })
         );

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -335,6 +335,7 @@ describe('Message API:', () => {
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.be.an('array');
+                expect(res.body.length).to.not.equal(0);
                 expect(res.body[0].from).to.equal(testMessageArray[0].from);
                 expect(res.body[0].to).to.deep.equal(testMessageArray[0].to);
                 return;
@@ -347,6 +348,7 @@ describe('Message API:', () => {
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.be.an('array');
+                expect(res.body.length).to.not.equal(0);
                 expect(() => {
                     let i;
                     for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus
@@ -365,6 +367,7 @@ describe('Message API:', () => {
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.be.an('array');
+                expect(res.body.length).to.not.equal(0);
                 expect(() => {
                     let i;
                     for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -386,6 +386,7 @@ describe('Message API:', () => {
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.be.an('array');
+                expect(res.body.length).to.not.equal(0);
                 expect(() => {
                     let i;
                     for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -359,8 +359,8 @@ describe('Message API:', () => {
             })
         );
 
-        it('has an option to filter by recieved messages', () => request(app)
-            .get(`${baseURL}/message/list?recieved=true`)
+        it('has an option to filter by received messages', () => request(app)
+            .get(`${baseURL}/message/list?received=true`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
             .then((res) => {


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
Adds extra filters to the /list endpoint
#### Related JIRA tickets:
https://jira.amida-tech.com/browse/SER-158
#### How should this be manually tested?
#### Any background context you want to provide?
Added offset for pagination, which can be used alongside limit. 
I assumed that sent was for messages that are "from" the user and received are messages "to" the user. 
#### Screenshots (if appropriate):