### PR TITLE
Bug/SE-161 Simplify message scopes

### DIFF
--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -4,25 +4,10 @@ import APIError from '../helpers/APIError';
 
 const Message = db.Message;
 
-const useUnscoped = (url) => {
-    const unscopedRoutes = ['/unarchive/', '/delete/'];
-    return unscopedRoutes.find(route => url.includes(route)) !== undefined;
-};
-const useUnscopedArchived = (url) => {
-    const unscopedRoutes = ['/reply/'];
-    return unscopedRoutes.find(route => url.includes(route)) !== undefined;
-};
-
-
 /**
  * Used to load appropriate scope per request.
  */
 const messageScope = function messageScope(req) {
-    if (useUnscoped(req.originalUrl)) {
-        return Message.scope({ method: ['findAllForUser', req.user] });
-    } else if (useUnscopedArchived(req.originalUrl)) {
-        return Message.scope({ method: ['forUserNonDeleted', req.user] });
-    }
     return Message.scope({ method: ['forUser', req.user] });
 };
 

--- a/server/controllers/thread.controller.js
+++ b/server/controllers/thread.controller.js
@@ -5,7 +5,7 @@ import APIError from '../helpers/APIError';
 const Message = db.Message;
 
 function get(req, res, next) {
-    Message.scope({ method: ['findAllForUser', req.user] })
+    Message.scope({ method: ['forUser', req.user] })
         .findAll({
             where: {
                 originalMessageId: req.params.originalMessageId,

--- a/server/controllers/thread.controller.js
+++ b/server/controllers/thread.controller.js
@@ -102,10 +102,10 @@ function list(req, res, next) {
     queryObject.group = 'originalMessageId';
     queryObject.attributes = [from, originalMessageId, mostRecent, count, isArchived, unread];
 
-    Message.scope({ method: ['findAllForUser', req.user] })
+    Message.scope({ method: ['forUser', req.user] })
         .findAll(queryObject)
         .then((threadsResponse) => {
-            Message.scope({ method: ['findAllForUser', req.user] })
+            Message.scope({ method: ['forUser', req.user] })
             .findAll({ raw: true })
             .then((allMessages) => {
                 const threads = threadsResponse;

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -71,22 +71,6 @@ module.exports = (sequelize, DataTypes) => {
                     where: {
                         owner: user.username,
                         isDeleted: false,
-                        isArchived: false,
-                    },
-                };
-            },
-            forUserNonDeleted(user) {
-                return {
-                    where: {
-                        owner: user.username,
-                        isDeleted: false,
-                    },
-                };
-            },
-            findAllForUser(user) {
-                return {
-                    where: {
-                        owner: user.username,
                     },
                 };
             },

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -3,6 +3,9 @@ import request from 'supertest';
 import httpStatus from 'http-status';
 import { expect } from 'chai';
 
+import {
+    Message,
+} from '../../config/sequelize';
 import { auth, auth2, baseURL, app } from './common.integration.js';
 
 
@@ -18,50 +21,180 @@ const inaccessibleMessageObject = {
     message: '*Self destruct*',
 };
 
+const now = new Date();
+
+const boilerPlate = {
+    subject: 'subject',
+    message: 'message',
+    isDeleted: false,
+    isArchived: false,
+    createdAt: now,
+    updatedAt: now,
+    readAt: null,
+    owner: 'user0',
+    from: 'user0',
+    to: ['user0'],
+};
+
+const getThreadsTestObject = [
+    {
+        id: 1,
+        originalMessageId: 1,
+        parentMessageId: null,
+    },
+    // thread with one archived
+    {
+        id: 2,
+        originalMessageId: 2,
+        parentMessageId: null,
+    },
+    {
+        id: 3,
+        originalMessageId: 2,
+        parentMessageId: 2,
+        isArchived: true,
+    },
+    // thread with all archived
+    {
+        id: 4,
+        originalMessageId: 4,
+        parentMessageId: null,
+        isArchived: true,
+    },
+    {
+        id: 5,
+        originalMessageId: 4,
+        parentMessageId: 4,
+        isArchived: true,
+    },
+    // thread with one read
+    {
+        id: 6,
+        originalMessageId: 6,
+        parentMessageId: null,
+    },
+    {
+        id: 7,
+        originalMessageId: 6,
+        parentMessageId: 6,
+        readAt: new Date(),
+    },
+    // thread with all read
+    {
+        id: 8,
+        originalMessageId: 8,
+        parentMessageId: null,
+        readAt: new Date(),
+    },
+    {
+        id: 9,
+        from: 'user1',
+        originalMessageId: 8,
+        parentMessageId: 8,
+        readAt: new Date(),
+    },
+    // deleted
+    {
+        id: 10,
+        origionalMessageId: 10,
+        parentMessageId: null,
+        isDeleted: true,
+    },
+].map(message => Object.assign({}, boilerPlate, message));
+
 describe('Thread API:', () => {
     describe('GET /thread/', () => {
-        let originalMessageId;
-        let lastCreatedAt;
+        before(() => Message
+            .destroy({ where: {}, truncate: true })
+            .then(() => Message.bulkCreate(getThreadsTestObject)));
 
-        const responseMessageObject = {
-            to: ['user1', 'user2'],
-            subject: 'Test Message',
-            message: 'Response post please ignore',
-        };
+        after(() => Message
+            .destroy({ where: {}, truncate: true }));
 
-        before(() => request(app)
-            .post(`${baseURL}/message/send`)
-            .set('Authorization', `Bearer ${auth}`)
-            .send(testMessageObject)
-            .then((message) => {
-                originalMessageId = message.body.originalMessageId;
-                return request(app)
-                .post(`${baseURL}/message/reply/${originalMessageId}`)
-                .set('Authorization', `Bearer ${auth}`)
-                .send(responseMessageObject)
-                .then((response) => {
-                    lastCreatedAt = response.body.createdAt;
-                });
-            })
-            .then(() => request(app)
-                .post(`${baseURL}/message/send`)
-                .set('Authorization', `Bearer ${auth2}`)
-                .send(inaccessibleMessageObject)
-            )
-        );
-
-        it('should return tread summaries', () => request(app)
+        it('should return thread summaries', () => request(app)
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.be.an('array');
-                expect(res.body.length).to.equal(1);
-                expect(res.body[0].originalMessageId).to.equal(originalMessageId);
-                expect(res.body[0].mostRecent).to.equal(lastCreatedAt);
-                expect(res.body[0].unread).to.equal(false);
-                expect(res.body[0].count).to.equal(2);
-                expect(res.body[0].subject).to.equal(testMessageObject.subject);
+                expect(res.body.length).to.equal(5);
+                expect(res.body.map(thread => thread.originalMessageId)).to.not.include(10);
+            })
+        );
+
+        it('should produce a correct isArchived value', () => request(app)
+            .get(`${baseURL}/thread`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                const isArchived = [false, false, true, false, false];
+                res.body.forEach((thread, index) => {
+                    expect(thread.isArchived, `isArchived[${index}]`).to.equal(isArchived[index]);
+                });
+            })
+        );
+
+        it('should produce a correct unread value', () => request(app)
+            .get(`${baseURL}/thread`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                const unread = [true, true, true, true, false];
+                res.body.forEach((thread, index) => {
+                    expect(thread.unread, `unread[${index}]`).to.equal(unread[index]);
+                });
+            })
+        );
+
+        it('should produce a correct count value', () => request(app)
+            .get(`${baseURL}/thread`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                const count = [1, 2, 2, 2, 2];
+                res.body.forEach((thread, index) => {
+                    expect(thread.count, `count[${index}]`).to.equal(count[index]);
+                });
+            })
+        );
+
+        it('should produce a correct from value', () => request(app)
+            .get(`${baseURL}/thread`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                const from = [['user0'],
+                    ['user0'],
+                    ['user0'],
+                    ['user0'],
+                    ['user0', 'user1']];
+                res.body.forEach((thread, index) => {
+                    expect(thread.from, `from[${index}]`).to.deep.equal(from[index]);
+                });
+            })
+        );
+
+        it('should support limit parameter', () => request(app)
+            .get(`${baseURL}/thread?limit=1`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(res.body).to.have.length(1);
+            })
+        );
+
+        it('should support offset parameter', () => request(app)
+            .get(`${baseURL}/thread?offset=1`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(res.body[0].originalMessageId).to.equal(2);
             })
         );
     });

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -42,6 +42,16 @@ describe('Thread API:', () => {
                 .send(responseMessageObject)
                 .then((response) => {
                     responseMessageId = response.body.id;
+                    return request(app)
+                    .post(`${baseURL}/message/reply/${responseMessageId}`)
+                    .set('Authorization', `Bearer ${auth}`)
+                    .send(responseMessageObject)
+                    .expect(httpStatus.OK)
+                    .then(deleteResponse => request(app)
+                        .delete(`${baseURL}/message/delete/${deleteResponse.body.id}`)
+                        .set('Authorization', `Bearer ${auth}`)
+                        .send()
+                        .expect(httpStatus.OK));
                 });
             })
             .then(() => request(app)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,6 +1556,10 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+email-validator@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/email-validator/-/email-validator-1.1.1.tgz#b07f3be7bac1dc099bc43e75f6ae399f552d5a80"
+
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"
@@ -3650,15 +3654,9 @@ mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
+"minimatch@2 || 3", minimatch@3.0.3, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
-  dependencies:
-    brace-expansion "^1.0.0"
-
-minimatch@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.2.tgz#0f398a7300ea441e9c348c83d98ab8c9dbf9c40a"
   dependencies:
     brace-expansion "^1.0.0"
 
@@ -4289,6 +4287,10 @@ proxy-addr@~2.0.2:
     forwarded "~0.1.2"
     ipaddr.js "1.5.2"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 ps-tree@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
@@ -4430,6 +4432,12 @@ rechoir@^0.6.2:
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   dependencies:
     resolve "^1.1.6"
+
+recursive-readdir@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/recursive-readdir/-/recursive-readdir-2.2.1.tgz#90ef231d0778c5ce093c9a48d74e5c5422d13a99"
+  dependencies:
+    minimatch "3.0.3"
 
 referrer-policy@1.1.0:
   version "1.1.0"
@@ -4853,9 +4861,9 @@ snyk-config@1.0.1:
     nconf "^0.7.2"
     path-is-absolute "^1.0.0"
 
-snyk-go-plugin@1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/snyk-go-plugin/-/snyk-go-plugin-1.3.8.tgz#77f7fc663b276d4e6007c5bd23ec2453c35a45ee"
+snyk-go-plugin@1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/snyk-go-plugin/-/snyk-go-plugin-1.4.5.tgz#bf462656caade0603970b68e756f4b389c3aeaaa"
   dependencies:
     graphlib "^2.1.1"
     toml "^2.3.2"
@@ -4873,23 +4881,31 @@ snyk-module@1.8.1, snyk-module@^1.6.0, snyk-module@^1.8.1:
     debug "^2.2.0"
     hosted-git-info "^2.1.4"
 
-snyk-mvn-plugin@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.0.tgz#6ad3fb670cd22972094f065ab99b90d286c8ad6f"
+snyk-mvn-plugin@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.1.tgz#15c13131a368dde487763de93557ad5fb9572ffe"
 
-snyk-nuget-plugin@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.0.3.tgz#51e5085f58d35def7c971258836c52f5e2857a6e"
+snyk-nuget-plugin@1.3.9:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.9.tgz#bcdc503eafe9f3eeb4024b756ded4d0c3b265d12"
   dependencies:
+    debug "^3.1.0"
     es6-promise "^4.1.1"
     xml2js "^0.4.17"
     zip "^1.2.0"
 
-snyk-policy@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/snyk-policy/-/snyk-policy-1.7.1.tgz#e413b6bd4af6050c5e5f445287909e4e98a09b22"
+snyk-php-plugin@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/snyk-php-plugin/-/snyk-php-plugin-1.3.2.tgz#51c19171dee0cd35158a7aa835fe02a97dc84ab8"
+  dependencies:
+    debug "^3.1.0"
+
+snyk-policy@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/snyk-policy/-/snyk-policy-1.10.1.tgz#b1a26c8aef529c61604aca382111e535d511b763"
   dependencies:
     debug "^2.2.0"
+    email-validator "^1.1.1"
     es6-promise "^3.1.2"
     js-yaml "^3.5.3"
     lodash.clonedeep "^4.3.1"
@@ -4899,15 +4915,9 @@ snyk-policy@1.7.1:
     snyk-try-require "^1.1.1"
     then-fs "^2.0.0"
 
-snyk-python-plugin@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/snyk-python-plugin/-/snyk-python-plugin-1.4.0.tgz#4c085ff7ff1eaafb18e4d12225f76bb8adc9d60f"
-
-snyk-recursive-readdir@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/snyk-recursive-readdir/-/snyk-recursive-readdir-2.0.0.tgz#5cb59e94698169e0205a60e7d6a506d0b4d52ff3"
-  dependencies:
-    minimatch "3.0.2"
+snyk-python-plugin@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/snyk-python-plugin/-/snyk-python-plugin-1.5.3.tgz#0d0d2ced89a4280a5108f00b5e076c631e1a6a1b"
 
 snyk-resolve-deps@1.7.0:
   version "1.7.0"
@@ -4935,9 +4945,11 @@ snyk-resolve@1.0.0, snyk-resolve@^1.0.0:
     debug "^2.2.0"
     then-fs "^2.0.0"
 
-snyk-sbt-plugin@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.0.tgz#9a72c6af42bbaa1cf76c5443669cb008347260b7"
+snyk-sbt-plugin@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.2.tgz#2bc2303b2ccae9d8e27468eb2300f77b7dafcca5"
+  dependencies:
+    debug "^2.2.0"
 
 snyk-tree@^1.0.0:
   version "1.0.0"
@@ -4955,9 +4967,9 @@ snyk-try-require@^1.1.1, snyk-try-require@^1.2.0:
     lru-cache "^4.0.0"
     then-fs "^2.0.0"
 
-snyk@^1.41.1:
-  version "1.48.1"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.48.1.tgz#4b1dcdc4a262cbe0fc50d5f6eec8328cb46f5fd8"
+snyk@^1.69.4:
+  version "1.69.5"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.69.5.tgz#18f280bd39e50f97b80dfd5a29b0d069afb37d6c"
   dependencies:
     abbrev "^1.0.7"
     ansi-escapes "^1.3.0"
@@ -4970,19 +4982,21 @@ snyk@^1.41.1:
     needle "^2.0.1"
     open "^0.0.5"
     os-name "^1.0.3"
+    proxy-from-env "^1.0.0"
+    recursive-readdir "^2.2.1"
     semver "^5.1.0"
     snyk-config "1.0.1"
-    snyk-go-plugin "1.3.8"
+    snyk-go-plugin "1.4.5"
     snyk-gradle-plugin "1.2.0"
     snyk-module "1.8.1"
-    snyk-mvn-plugin "1.1.0"
-    snyk-nuget-plugin "1.0.3"
-    snyk-policy "1.7.1"
-    snyk-python-plugin "1.4.0"
-    snyk-recursive-readdir "^2.0.0"
+    snyk-mvn-plugin "1.1.1"
+    snyk-nuget-plugin "1.3.9"
+    snyk-php-plugin "1.3.2"
+    snyk-policy "^1.10.1"
+    snyk-python-plugin "1.5.3"
     snyk-resolve "1.0.0"
     snyk-resolve-deps "1.7.0"
-    snyk-sbt-plugin "1.2.0"
+    snyk-sbt-plugin "1.2.2"
     snyk-tree "^1.0.0"
     snyk-try-require "^1.2.0"
     tempfile "^1.1.1"


### PR DESCRIPTION
#### What's this PR do?
1. Simplifies Message model scopes to make all non-deleted messages available to all endpoints to resolve acute issues:
2. Deleted messages included in GET /thread/:originalMessageId responses and
3. Clients are able to unarchive deleted messages

#### Related JIRA tickets:
[SER-161](https://jira.amida-tech.com/browse/SER-161)

#### How should this be manually tested?
1. Check that new tests correctly test that the unarchive endpoint cannot access deleted messages and that deleted messages are not included in thread responses
1. Check that you agree that archived messages should not result in 404 for GET /message/get/:messageId

#### Any background context you want to provide?
After this PR, there is no way to retrieve only unarchived messages from the /message/list endpoint, which was previously the default. I have captured this in a ticket and will resolve after the PR for the other /message/list flags (https://github.com/amida-tech/amida-messaging-microservice/pull/38) is complete: (https://jira.amida-tech.com/browse/SER-162)

#### Screenshots (if appropriate):