### PR TITLE
Feature/SER-166 archived query parameter for GET /thread

### DIFF
--- a/server/controllers/thread.controller.js
+++ b/server/controllers/thread.controller.js
@@ -93,6 +93,13 @@ function list(req, res, next) {
         queryObject.offset = req.query.offset;
     }
 
+    if (req.query.archived !== undefined) {
+        queryObject.having =
+            Sequelize.where(Sequelize.fn('bool_and', Sequelize.col('isArchived')),
+            { $eq: req.query.archived }
+        );
+    }
+
     const from = [Sequelize.fn('ARRAY_AGG', Sequelize.fn('DISTINCT', Sequelize.col('from'))), 'from'];
     const originalMessageId = 'originalMessageId';
     const mostRecent = [Sequelize.fn('MAX', Sequelize.col('createdAt')), 'mostRecent'];

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -220,6 +220,16 @@ describe('Thread API:', () => {
                 expect(res.body[3].isArchived).to.equal(false);
             })
         );
+
+        it('should offset and limit archive-filtered results', () => request(app)
+            .get(`${baseURL}/thread?archived=false&offset=1&limit=1`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.have.length(1);
+                expect(res.body[0].originalMessageId).to.equal(2);
+            })
+        );
     });
 
     describe('GET /thread/:originalMessageId', () => {

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -197,6 +197,29 @@ describe('Thread API:', () => {
                 expect(res.body[0].originalMessageId).to.equal(2);
             })
         );
+
+        it('should support archived=true parameter', () => request(app)
+            .get(`${baseURL}/thread?archived=true`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.have.length(1);
+                expect(res.body[0].isArchived).to.equal(true);
+            })
+        );
+
+        it('should support archived=false parameter', () => request(app)
+            .get(`${baseURL}/thread?archived=false`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.have.length(4);
+                expect(res.body[0].isArchived).to.equal(false);
+                expect(res.body[1].isArchived).to.equal(false);
+                expect(res.body[2].isArchived).to.equal(false);
+                expect(res.body[3].isArchived).to.equal(false);
+            })
+        );
     });
 
     describe('GET /thread/:originalMessageId', () => {


### PR DESCRIPTION
#### What's this PR do?
Adds support for an `archived={true|false}` parameter to GET /thread

#### Related JIRA tickets:
[SER-166](https://jira.amida-tech.com/browse/SER-166)

#### How should this be manually tested?
Populate a set of message threads and check `?archived=true` returns exactly those threads that contain only archived messages, and that `?archived=false` returns exactly those threads that contain at least one unarchived message.

#### Any background context you want to provide?
Jan 30 commits are from #39 

#### Screenshots (if appropriate):