### PR TITLE
Feature/SER-162 Support `?archived=false` in /message/list

### DIFF
--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -162,27 +162,27 @@ function list(req, res) {
         queryObject.where = { ...queryObject.where, ...whereObject };
     }
 
-    if (req.query.limit) {
+    if (req.query.limit !== undefined) {
         queryObject.limit = req.query.limit;
     }
 
-    if (req.query.offset) {
+    if (req.query.offset !== undefined) {
         queryObject.offset = req.query.offset;
     }
 
-    if (req.query.summary) {
+    if (req.query.summary === 'true') {
         queryObject.attributes = ['subject', 'from', 'createdAt'];
     }
 
-    if (req.query.received) {
+    if (req.query.received === 'true') {
         queryObject.where.to = { $contains: [req.user.username] };
     }
 
-    if (req.query.sent) {
+    if (req.query.sent === 'true') {
         queryObject.where.from = req.user.username;
     }
 
-    if (req.query.unread) {
+    if (req.query.unread === 'true') {
         queryObject.where.readAt = null;
     }
 

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -186,19 +186,14 @@ function list(req, res) {
         queryObject.where.readAt = null;
     }
 
-    if (req.query.archived && req.query.archived === 'true') {
-        queryObject.where.isArchived = true;
-        queryObject.where.isDeleted = false;
-        queryObject.where.owner = req.user.username;
-        Message
-            .unscoped().findAll(queryObject)
-            .then(results => res.send(results));
-    } else {
-        Message
-          .scope({ method: ['forUser', req.user] })
-          .findAll(queryObject)
-          .then(results => res.send(results));
+    if (req.query.archived !== undefined) {
+        queryObject.where.isArchived = req.query.archived === 'true';
     }
+
+    Message
+        .scope({ method: ['forUser', req.user] })
+        .findAll(queryObject)
+        .then(results => res.send(results));
 }
 
 function count() {}

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -31,13 +31,14 @@ const fromArray = ['user0', 'user1', 'user2', 'user3'];
 const MessageUnscoped = Message.unscoped();
 // 4 senders send message to 4 recipients each
 fromArray.forEach((receiver) => {
-    fromArray.forEach((sender) => {
+    fromArray.forEach((sender, index) => {
         testMessageArray.push({
             to: fromArray,
             from: sender,
             subject: 'Test Message',
             message: 'Test post please ignore',
             owner: receiver,
+            isArchived: index < 1,
         });
     });
 });
@@ -410,6 +411,28 @@ describe('Message API:', () => {
                     }
                 }).to.not.throw();
                 return;
+            })
+        );
+
+        it('has an option to filter by archived messages', () => request(app)
+            .get(`${baseURL}/message/list?archived=true`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(res.body.length).to.equal(1);
+                expect(res.body[0].isArchived).to.equal(true);
+            })
+        );
+
+        it('has an option to filter by unarchived messages', () => request(app)
+            .get(`${baseURL}/message/list?archived=false`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                expect(res.body.length).to.equal(3);
+                res.body.forEach(message => expect(message.isArchived).to.equal(false));
             })
         );
 

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -23,7 +23,7 @@ const inaccessibleMessageObject = {
 
 const now = new Date();
 
-const boilerPlate = {
+const threadMessageTemplate = {
     subject: 'subject',
     message: 'message',
     isDeleted: false,
@@ -100,7 +100,7 @@ const getThreadsTestObject = [
         parentMessageId: null,
         isDeleted: true,
     },
-].map(message => Object.assign({}, boilerPlate, message));
+].map(message => Object.assign({}, threadMessageTemplate, message));
 
 describe('Thread API:', () => {
     describe('GET /thread/', () => {


### PR DESCRIPTION
#### What's this PR do?
Adds support for querying for unarchived messages with `?archived=false` in GET /message/list, which previously only supported `?archived=true`.
Adds strict value checks for other query parameters

#### Related JIRA tickets:
[SER-162](https://jira.amida-tech.com/browse/SER-162)

#### How should this be manually tested?
Populate messages with some archived and some unarchived messages. Check that GET /message/list?archived=false only returns unarchived messages.

#### Any background context you want to provide?
Feb 02 commits from #41, Jan 30 commits from #39 

#### Screenshots (if appropriate):