### PR TITLE
Feature/SER-167 Message IDs in thread summary response

### DIFF
--- a/server/controllers/thread.controller.js
+++ b/server/controllers/thread.controller.js
@@ -106,8 +106,10 @@ function list(req, res, next) {
     const count = [Sequelize.fn('COUNT', Sequelize.col('id')), 'count'];
     const isArchived = [Sequelize.fn('bool_and', Sequelize.col('isArchived')), 'isArchived'];
     const unread = [Sequelize.fn('bool_or', (Sequelize.literal('CASE WHEN "readAt" IS NULL THEN true ELSE false END'))), 'unread'];
+    const messageIds = [Sequelize.fn('ARRAY_AGG', Sequelize.col('id')), 'messageIds'];
     queryObject.group = 'originalMessageId';
-    queryObject.attributes = [from, originalMessageId, mostRecent, count, isArchived, unread];
+    queryObject.attributes =
+        [from, originalMessageId, mostRecent, count, isArchived, unread, messageIds];
 
     Message.scope({ method: ['forUser', req.user] })
         .findAll(queryObject)

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -178,6 +178,19 @@ describe('Thread API:', () => {
             })
         );
 
+        it('should produce a correct messageIds value', () => request(app)
+            .get(`${baseURL}/thread`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.be.an('array');
+                const messageIds = [[1], [2, 3], [4, 5], [6, 7], [8, 9]];
+                res.body.forEach((thread, index) => {
+                    expect(thread.messageIds, `messageIds[${index}]`).to.deep.equal(messageIds[index]);
+                });
+            })
+        );
+
         it('should support limit parameter', () => request(app)
             .get(`${baseURL}/thread?limit=1`)
             .set('Authorization', `Bearer ${auth}`)


### PR DESCRIPTION
#### What's this PR do?
Includes the array of Message ids in a thread in the thread summary object in response to `GET /thread`

#### Related JIRA tickets:
[SER-167](https://jira.amida-tech.com/browse/SER-167)

#### How should this be manually tested?
1. Generate a thread of messages
1. Submit a query to `GET /thread` and check that the response objects include `messageIds`, an array of individual Message IDs in the thread.

#### Any background context you want to provide?
This is a minimal implementation of a feature that allows a client to operate on the individual messages in a thread without querying for the full message data. For example, to mark all messages in a thread as read, the client needs the message ids. An alternative would be to duplicate the /message PUT endpoints like markAsRead and archive at the thread level. I think it is better, in this case, to reduce the footprint in the messaging service API, particularly since there is a separate effort to define a more full-featured thread-level api.

#### Screenshots (if appropriate):