### PR TITLE
Feature/SER-171 Message and thread summary results in descending time order

### DIFF
--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -154,6 +154,7 @@ function reply(req, res, next) {
 function list(req, res) {
     const queryObject = {
         where: {},
+        order: [['createdAt', 'DESC']],
     };
 
     if (req.query.from) {

--- a/server/controllers/thread.controller.js
+++ b/server/controllers/thread.controller.js
@@ -83,6 +83,7 @@ function list(req, res, next) {
     const queryObject = {
         raw: true,
         where: {},
+        order: [[Sequelize.fn('MAX', Sequelize.col('createdAt')), 'DESC']],
     };
 
     if (req.query.limit) {

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -29,9 +29,12 @@ const testMessageObject = {
 const testMessageArray = [];
 const fromArray = ['user0', 'user1', 'user2', 'user3'];
 const MessageUnscoped = Message.unscoped();
+let date = new Date();
 // 4 senders send message to 4 recipients each
 fromArray.forEach((receiver) => {
     fromArray.forEach((sender, index) => {
+        date = new Date(date);
+        date.setSeconds(date.getSeconds() + 1);
         testMessageArray.push({
             to: fromArray,
             from: sender,
@@ -39,6 +42,7 @@ fromArray.forEach((receiver) => {
             message: 'Test post please ignore',
             owner: receiver,
             isArchived: index < 1,
+            createdAt: date,
         });
     });
 });
@@ -322,6 +326,21 @@ describe('Message API:', () => {
             })
         );
 
+        it('should return newest messages first', () => request(app)
+            .get(`${baseURL}/message/list`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body.length).to.be.greaterThan(1);
+                res.body.forEach((message, index) => {
+                    if (index < res.body.length - 1) {
+                        expect(message.createdAt > res.body[index + 1].createdAt, `index: ${index}`)
+                        .to.equal(true);
+                    }
+                });
+            })
+        );
+
         it('has an option to limit Messages returned', () => request(app)
             .get(`${baseURL}/message/list?limit=${limit}`)
             .set('Authorization', `Bearer ${auth}`)
@@ -442,10 +461,10 @@ describe('Message API:', () => {
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.be.an('array');
-                expect(res.body[0].from).to.equal(testMessageArray[0].from);
-                expect(res.body[0].subject).to.be.a('string');
-                expect(res.body[0].to).to.be.a('undefined');
-                expect(res.body[0].message).to.be.a('undefined');
+                expect(res.body[3].from).to.equal(testMessageArray[0].from);
+                expect(res.body[3].subject).to.be.a('string');
+                expect(res.body[3].to).to.be.a('undefined');
+                expect(res.body[3].message).to.be.a('undefined');
                 return;
             })
         );


### PR DESCRIPTION
#### What's this PR do?
Orders the queries for messages and thread summaries by descending time, `mostRecent` for thread summaries and `createdAt` for messages.

#### Related JIRA tickets:
[SER-171](https://jira.amida-tech.com/browse/SER-171)

#### How should this be manually tested?
1. Query for thread summaries and messages and check that the results are in descending order by time.

#### Any background context you want to provide?
#### Screenshots (if appropriate):