### PR TITLE
Feature/SER-175 Include count in list endpoint responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amida-messaging-microservice",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Microservice for a lightweight messaging application",
   "author": "Jacob Sachs <jacob@amida.com>",
   "main": "index.js",

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -193,8 +193,10 @@ function list(req, res) {
 
     Message
         .scope({ method: ['forUser', req.user] })
-        .findAll(queryObject)
-        .then(results => res.send(results));
+        .findAndCountAll(queryObject)
+        .then(response =>
+            res.send({ messages: response.rows, count: response.count })
+        );
 }
 
 function count() {}

--- a/server/controllers/thread.controller.js
+++ b/server/controllers/thread.controller.js
@@ -113,8 +113,8 @@ function list(req, res, next) {
         [from, originalMessageId, mostRecent, count, isArchived, unread, messageIds];
 
     Message.scope({ method: ['forUser', req.user] })
-        .findAll(queryObject)
-        .then((threadsResponse) => {
+        .findAndCountAll(queryObject)
+        .then(({ rows: threadsResponse, count: findCount }) => {
             Message.scope({ method: ['forUser', req.user] })
             .findAll({ raw: true })
             .then((allMessages) => {
@@ -132,7 +132,7 @@ function list(req, res, next) {
                     threads[i].subject
                       = findFirstSubjectText(threads[i], allMessages);
                 }
-                res.send(threads);
+                res.send({ threads, count: findCount.length });
             });
         })
         .catch(next);

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -319,9 +319,11 @@ describe('Message API:', () => {
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
             .then((res) => {
+                const owned = testMessageArray.filter(message => message.owner === 'user0');
                 expect(res.body).to.be.an('array');
-                expect(res.body.from).to.equal(testMessageArray.from);
-                expect(res.body.to).to.equal(testMessageArray.to);
+                expect(res.body.map(message => message.from))
+                .to.deep.equal(owned.map(message => message.from).reverse());
+                res.body.forEach(message => expect(message.to).to.deep.equal(fromArray));
                 return;
             })
         );

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -440,6 +440,44 @@ describe('Message API:', () => {
                 expect(messages[3].message).to.be.a('undefined');
             })
         );
+
+        it('returns the count of all messages', () => request(app)
+            .get(`${baseURL}/message/list`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count } }) => {
+                expect(count).to.equal(4);
+            })
+        );
+
+        it('returns the count for archived queries', () => request(app)
+            .get(`${baseURL}/message/list?archived=false`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count } }) => {
+                expect(count).to.equal(3);
+            })
+        );
+
+        it('returns the unlimited count for limited queries', () => request(app)
+            .get(`${baseURL}/message/list?limit=1`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count, messages } }) => {
+                expect(count).to.equal(4);
+                expect(messages.length).to.equal(1);
+            })
+        );
+
+        it('returns the unlimited, filtered count for limited, filtered queries', () => request(app)
+            .get(`${baseURL}/message/list?limit=1&archived=false`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count, messages } }) => {
+                expect(count).to.equal(3);
+                expect(messages.length).to.equal(1);
+            })
+        );
     });
 
     // describe('GET /message/count/:userId', function () {

--- a/server/tests/message.integration.spec.js
+++ b/server/tests/message.integration.spec.js
@@ -318,13 +318,12 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
+            .then(({ body: { messages } }) => {
                 const owned = testMessageArray.filter(message => message.owner === 'user0');
-                expect(res.body).to.be.an('array');
-                expect(res.body.map(message => message.from))
+                expect(messages).to.be.an('array');
+                expect(messages.map(message => message.from))
                 .to.deep.equal(owned.map(message => message.from).reverse());
-                res.body.forEach(message => expect(message.to).to.deep.equal(fromArray));
-                return;
+                messages.forEach(message => expect(message.to).to.deep.equal(fromArray));
             })
         );
 
@@ -332,11 +331,11 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body.length).to.be.greaterThan(1);
-                res.body.forEach((message, index) => {
-                    if (index < res.body.length - 1) {
-                        expect(message.createdAt > res.body[index + 1].createdAt, `index: ${index}`)
+            .then(({ body: { messages } }) => {
+                expect(messages.length).to.be.greaterThan(1);
+                messages.forEach((message, index) => {
+                    if (index < messages.length - 1) {
+                        expect(message.createdAt > messages[index + 1].createdAt, `index: ${index}`)
                         .to.equal(true);
                     }
                 });
@@ -347,10 +346,9 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?limit=${limit}`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.be.at.most(limit);
-                return;
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.be.at.most(limit);
             })
         );
 
@@ -358,10 +356,9 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?offset=${testMessageArray.length - 1}`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.be.at.most(1);
-                return;
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.be.at.most(1);
             })
         );
 
@@ -369,12 +366,11 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?from=${userName}`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.not.equal(0);
-                expect(res.body[0].from).to.equal(testMessageArray[0].from);
-                expect(res.body[0].to).to.deep.equal(testMessageArray[0].to);
-                return;
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.not.equal(0);
+                expect(messages[0].from).to.equal(testMessageArray[0].from);
+                expect(messages[0].to).to.deep.equal(testMessageArray[0].to);
             })
         );
 
@@ -382,18 +378,9 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?sent=true`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.not.equal(0);
-                expect(() => {
-                    let i;
-                    for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus
-                        if (res.body[i].from !== userName) {
-                            throw new Error(`${res.body[i].from} does not equal ${userName}`);
-                        }
-                    }
-                }).to.not.throw();
-                return;
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.not.equal(0);
             })
         );
 
@@ -401,18 +388,10 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?received=true`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.not.equal(0);
-                expect(() => {
-                    let i;
-                    for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus
-                        if (!res.body[i].to.includes(userName)) {
-                            throw new Error(`${res.body[i].to} does not contain ${userName}`);
-                        }
-                    }
-                }).to.not.throw();
-                return;
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.not.equal(0);
+                messages.forEach(message => expect(message.to).to.include(userName));
             })
         );
 
@@ -420,18 +399,10 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?unread=true`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.not.equal(0);
-                expect(() => {
-                    let i;
-                    for (i = 0; i < res.body.length; i++) { // eslint-disable-line no-plusplus
-                        if (res.body[i].readAt) {
-                            throw new Error(`${res.body[i].readAt} message was already read`);
-                        }
-                    }
-                }).to.not.throw();
-                return;
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.not.equal(0);
+                messages.forEach(message => expect(message.readAt).to.be.a('null'));
             })
         );
 
@@ -439,10 +410,10 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?archived=true`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.equal(1);
-                expect(res.body[0].isArchived).to.equal(true);
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.equal(1);
+                expect(messages[0].isArchived).to.equal(true);
             })
         );
 
@@ -450,10 +421,10 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?archived=false`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.equal(3);
-                res.body.forEach(message => expect(message.isArchived).to.equal(false));
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages.length).to.equal(3);
+                messages.forEach(message => expect(message.isArchived).to.equal(false));
             })
         );
 
@@ -461,13 +432,12 @@ describe('Message API:', () => {
             .get(`${baseURL}/message/list?summary=${summary}`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body[3].from).to.equal(testMessageArray[0].from);
-                expect(res.body[3].subject).to.be.a('string');
-                expect(res.body[3].to).to.be.a('undefined');
-                expect(res.body[3].message).to.be.a('undefined');
-                return;
+            .then(({ body: { messages } }) => {
+                expect(messages).to.be.an('array');
+                expect(messages[3].from).to.equal(testMessageArray[0].from);
+                expect(messages[3].subject).to.be.a('string');
+                expect(messages[3].to).to.be.a('undefined');
+                expect(messages[3].message).to.be.a('undefined');
             })
         );
     });

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -115,10 +115,10 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body.length).to.equal(5);
-                expect(res.body.map(thread => thread.originalMessageId)).to.not.include(10);
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
+                expect(threads.length).to.equal(5);
+                expect(threads.map(thread => thread.originalMessageId)).to.not.include(10);
             })
         );
 
@@ -126,11 +126,11 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body.length).to.be.greaterThan(1);
-                res.body.forEach((thread, index) => {
-                    if (index < res.body.length - 1) {
-                        expect(thread.mostRecent > res.body[index + 1].mostRecent, `index: ${index}`)
+            .then(({ body: { threads } }) => {
+                expect(threads.length).to.be.greaterThan(1);
+                threads.forEach((thread, index) => {
+                    if (index < threads.length - 1) {
+                        expect(thread.mostRecent > threads[index + 1].mostRecent, `index: ${index}`)
                         .to.equal(true);
                     }
                 });
@@ -141,10 +141,10 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
                 const isArchived = [false, false, true, false, false];
-                res.body.forEach((thread, index) => {
+                threads.forEach((thread, index) => {
                     expect(thread.isArchived, `isArchived[${index}]`).to.equal(isArchived[index]);
                 });
             })
@@ -154,10 +154,10 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
                 const unread = [false, true, true, true, true];
-                res.body.forEach((thread, index) => {
+                threads.forEach((thread, index) => {
                     expect(thread.unread, `unread[${index}]`).to.equal(unread[index]);
                 });
             })
@@ -167,10 +167,10 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
                 const count = [2, 2, 2, 2, 1];
-                res.body.forEach((thread, index) => {
+                threads.forEach((thread, index) => {
                     expect(thread.count, `count[${index}]`).to.equal(count[index]);
                 });
             })
@@ -180,14 +180,14 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
                 const from = [['user0', 'user1'],
                     ['user0'],
                     ['user0'],
                     ['user0'],
                     ['user0']];
-                res.body.forEach((thread, index) => {
+                threads.forEach((thread, index) => {
                     expect(thread.from, `from[${index}]`).to.deep.equal(from[index]);
                 });
             })
@@ -197,10 +197,10 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
                 const messageIds = [[8, 9], [6, 7], [4, 5], [2, 3], [1]];
-                res.body.forEach((thread, index) => {
+                threads.forEach((thread, index) => {
                     expect(thread.messageIds, `messageIds[${index}]`).to.deep.equal(messageIds[index]);
                 });
             })
@@ -210,9 +210,9 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread?limit=1`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body).to.have.length(1);
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
+                expect(threads).to.have.length(1);
             })
         );
 
@@ -220,9 +220,9 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread?offset=1`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.be.an('array');
-                expect(res.body[0].originalMessageId).to.equal(6);
+            .then(({ body: { threads } }) => {
+                expect(threads).to.be.an('array');
+                expect(threads[0].originalMessageId).to.equal(6);
             })
         );
 
@@ -230,9 +230,9 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread?archived=true`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.have.length(1);
-                expect(res.body[0].isArchived).to.equal(true);
+            .then(({ body: { threads } }) => {
+                expect(threads).to.have.length(1);
+                expect(threads[0].isArchived).to.equal(true);
             })
         );
 
@@ -240,12 +240,12 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread?archived=false`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.have.length(4);
-                expect(res.body[0].isArchived).to.equal(false);
-                expect(res.body[1].isArchived).to.equal(false);
-                expect(res.body[2].isArchived).to.equal(false);
-                expect(res.body[3].isArchived).to.equal(false);
+            .then(({ body: { threads } }) => {
+                expect(threads).to.have.length(4);
+                expect(threads[0].isArchived).to.equal(false);
+                expect(threads[1].isArchived).to.equal(false);
+                expect(threads[2].isArchived).to.equal(false);
+                expect(threads[3].isArchived).to.equal(false);
             })
         );
 
@@ -253,9 +253,9 @@ describe('Thread API:', () => {
             .get(`${baseURL}/thread?archived=false&offset=1&limit=1`)
             .set('Authorization', `Bearer ${auth}`)
             .expect(httpStatus.OK)
-            .then((res) => {
-                expect(res.body).to.have.length(1);
-                expect(res.body[0].originalMessageId).to.equal(6);
+            .then(({ body: { threads } }) => {
+                expect(threads).to.have.length(1);
+                expect(threads[0].originalMessageId).to.equal(6);
             })
         );
     });

--- a/server/tests/thread.integration.spec.js
+++ b/server/tests/thread.integration.spec.js
@@ -258,6 +258,44 @@ describe('Thread API:', () => {
                 expect(threads[0].originalMessageId).to.equal(6);
             })
         );
+
+        it('returns the count of all threads', () => request(app)
+            .get(`${baseURL}/thread`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count } }) => {
+                expect(count).to.equal(5);
+            })
+        );
+
+        it('returns the count for archived queries', () => request(app)
+            .get(`${baseURL}/thread?archived=false`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count } }) => {
+                expect(count).to.equal(4);
+            })
+        );
+
+        it('returns the unlimited count for limited queries', () => request(app)
+            .get(`${baseURL}/thread?limit=1`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count, threads } }) => {
+                expect(count).to.equal(5);
+                expect(threads.length).to.equal(1);
+            })
+        );
+
+        it('returns the unlimited, filtered count for limited, filtered queries', () => request(app)
+            .get(`${baseURL}/thread?limit=1&archived=false`)
+            .set('Authorization', `Bearer ${auth}`)
+            .expect(httpStatus.OK)
+            .then(({ body: { count, threads } }) => {
+                expect(count).to.equal(4);
+                expect(threads.length).to.equal(1);
+            })
+        );
     });
 
     describe('GET /thread/:originalMessageId', () => {


### PR DESCRIPTION
#### What's this PR do?
Makes a breaking change.
Changes the responses to `GET /message/list` and `GET /thread` from a top-level list of the resource to be an object with the list and a count (`[messages]` becomes `{[messages], count}`).
The count value counts the resources that meet the `where` clause (meet the filter) but does not limit by the `offset` and `limit` parameters.
This is to support a paginating client that can now compute whether there are more messages after the current page, and can compute the total number of pages.

#### Related JIRA tickets:
[SER-175](https://jira.amida-tech.com/browse/SER-175)
Downstream ticket [INBA-750](https://jira.amida-tech.com/browse/INBA-750)

#### How should this be manually tested?
Populate a number of messages and threads. Check that the responses to `GET /message/list` and `GET /thread` are objects with a `messages` and `threads` list, respectively, and a `count` value with the number of resources matching the filter but not affected by `limit` or `offset`

#### Any background context you want to provide?
#### Screenshots (if appropriate):