### PR TITLE
adding support for ssl connections to postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,11 @@ PORT=4001
 PG_DB=amida_messaging_microservice
 PG_PORT=5432
 PG_HOST=localhost
-
 PG_USER=amida_messaging_microservice
 PG_PASSWD=
+PG_SSL=false
+PG_CERT_CA=''
+
 ENABLE_PUSH_NOTIFICATIONS=false
 AUTH_MICROSERVICE=http://localhost:4000/api
 NOTIFICATION_MICROSERVICE=http://localhost:4003/api

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Note: Default values are in parenthesis.
 
 `PG_PASSWD` (N/A) Password of postgres user `PG_USER`.
 
+`PG_SSL` (`=false`) Whether an ssl connection shall be used to connect to postgres.
+
+`PG_CERT_CA` If ssl is enabled with `PG_SSL` this can be set to a certificate to override the CAs trusted while initiating the ssl connection to postgres. Without this set, Mozilla's list of trusted CAs is used. Note that this variable should contain the certificate itself, not a filename.
+
 ### Running the Automated Test Suite:
 
 `TEST_TOKEN` (`=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIwIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwiYWRtaW4iOnRydWV9.X_SzIXZ-oqEL67eB-fwFqFSumuFQVAqhgsmak1JLIWo`) This is the `amida-auth-microservice` JWT that is used by this repo's automated test suite when it makes requests.

--- a/config/config.js
+++ b/config/config.js
@@ -21,6 +21,11 @@ const envVarsSchema = Joi.object({
         .description('Postgres username'),
     PG_PASSWD: Joi.string().allow('')
         .description('Postgres password'),
+    PG_SSL: Joi.bool()
+        .default(false)
+        .description('Enable SSL connection to PostgreSQL'),
+    PG_CERT_CA: Joi.string()
+        .description('SSL certificate CA'), // Certificate itself, not a filename
     TEST_TOKEN: Joi.string().allow('')
         .description('Test auth token'),
     AUTH_MICROSERVICE: Joi.string().allow('')
@@ -57,6 +62,8 @@ const config = {
         host: envVars.PG_HOST,
         user: envVars.PG_USER,
         passwd: envVars.PG_PASSWD,
+        ssl: envVars.PG_SSL,
+        ssl_ca_cert: envVars.PG_CERT_CA,
     },
 };
 

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -11,16 +11,30 @@ if (config.env === 'test') {
 
 const db = {};
 
-// // connect to postgres db
-const sequelize = new Sequelize(config.postgres.db,
-  config.postgres.user,
-  config.postgres.passwd,
-    {
-        dialect: 'postgres',
-        port: config.postgres.port,
-        host: config.postgres.host,
-        logging: dbLogging,
-    });
+// connect to postgres db
+const sequelizeOptions = {
+    dialect: 'postgres',
+    port: config.postgres.port,
+    host: config.postgres.host,
+    logging: dbLogging,
+};
+if (config.postgres.ssl) {
+    sequelizeOptions.ssl = config.postgres.ssl;
+    if (config.postgres.ssl_ca_cert) {
+        sequelizeOptions.dialectOptions = {
+            ssl: {
+                ca: config.postgres.ssl_ca_cert,
+            },
+        };
+    }
+}
+
+const sequelize = new Sequelize(
+    config.postgres.db,
+    config.postgres.user,
+    config.postgres.passwd,
+    sequelizeOptions
+);
 
 const Message = sequelize.import('../server/models/message.model');
 const User = sequelize.import('../server/models/user.model');


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
This adds env vars to support the option for using ssl to connect to postgres.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/SER-212

#### How should this be manually tested?
Setup a postgres instance with ssl required and run the tests against it.

I recommend using this docker image from ibm: 
https://www.ibm.com/support/knowledgecenter/en/SSPREK_9.0.4/com.ibm.isam.doc/admin/concept/con_postgresql_dockerfile.html

Setting up will look something like the following (assuming bash shell):

```
#run postgres with ssl
docker run --hostname isam.postgresql --name isam.postgresql \
--detach \
--publish 5432:5432 \
--volume /var/lib/postgresql/data \
--env POSTGRES_USER=postgres \
--env POSTGRES_PASSWORD=postgres \
--env POSTGRES_DB=auth \
--env POSTGRES_SSL_CN=isam.postgresql \
ibmcom/isam-postgresql:latest

# get self signed cert it generated
docker cp isam.postgresql:/var/lib/postgresql/data/public.pem .

# Set .env vars to appropriate values from above including PG_SSL=true

# Now if we set the cert ca to the self signed cert that the docker container generated, tests will pass
PG_CERT_CA=$(cat public.pem) yarn test

# the following without setting the ca will fail
yarn test
```

#### Any background context you want to provide?
Needed for upcoming deployment.
#### Screenshots (if appropriate):
N/A