### PR TITLE
Make log level configurable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-## Messaging Microservice ##
+## Shared ##
 NODE_ENV=development
+LOG_LEVEL=info
+
+## Messaging Microservice ##
 MESSAGING_SERVICE_PORT=4001
 
 MESSAGING_SERVICE_AUTOMATED_TEST_JWT=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InVzZXIwIiwiZW1haWwiOiJ0ZXN0QHRlc3QuY29tIiwiYWRtaW4iOnRydWV9.X_SzIXZ-oqEL67eB-fwFqFSumuFQVAqhgsmak1JLIWo

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,8 @@
-## Messaging Microservice ##
+## Shared ##
 NODE_ENV=production
+LOG_LEVEL=info
+
+## Messaging Microservice ##
 MESSAGING_SERVICE_PORT=4001
 
 MESSAGING_SERVICE_AUTOMATED_TEST_JWT=

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ A description of what the variable is or does.
 
 - Valid values are `development`, `production`, and `test`.
 
+##### `LOG_LEVEL` [`info`]
+
+- Valid values are [winston](https://github.com/winstonjs/winston) logging levels (`error`, `warn`, etc.).
+
 ##### `MESSAGING_SERVICE_PORT` (Required) [`4001`]
 
 The port this server will run on.

--- a/config/config.js
+++ b/config/config.js
@@ -14,6 +14,8 @@ const envVarsSchema = Joi.object({
     NODE_ENV: Joi.string()
         .allow(['development', 'production', 'test', 'provision'])
         .default('production'),
+    LOG_LEVEL: Joi.string()
+        .default('info'),
     MESSAGING_SERVICE_PORT: Joi.number()
         .default(4001),
     JWT_SECRET: Joi.string().required()
@@ -54,6 +56,7 @@ if (error) {
 
 const config = {
     env: envVars.NODE_ENV,
+    logLevel: envVars.LOG_LEVEL,
     port: envVars.MESSAGING_SERVICE_PORT,
     jwtSecret: envVars.JWT_SECRET,
     testToken: envVars.MESSAGING_SERVICE_AUTOMATED_TEST_JWT,

--- a/config/winston.js
+++ b/config/winston.js
@@ -5,7 +5,7 @@ const { createLogger, transports, format } = require('winston');
 const { printf, timestamp, combine, colorize } = format;
 
 const logger = createLogger({
-    level: 'info',
+    level: config.logLevel,
     transports: [
         new transports.Console(),
     ],


### PR DESCRIPTION
#### What's this PR do?
Makes the winston logging level configurable via the `LOG_LEVEL` environment variable.

#### Related JIRA tickets:

[ORANGE-852](https://jira.amida.com/browse/ORANGE-852)

#### How should this be manually tested?

1. Set your `LOG_LEVEL` in your `.env` file to any valid winston level (see winston documentation or the code below for valid levels)

2. Add these lines to any file (`index.js` would work nice).
```js
logger.error('this is error');
logger.warn('this is warn');
logger.info('this is info');
logger.verbose('this is verbose');
logger.debug('this is debug');
logger.silly('this is silly');
```
3. `yarn start` and ensure you only see print the statements of the level you set and levels below it. Ex, if `LOG_LEVEL=info`, you should only see print:
```sh
this is error
this is warn
this is info
```

4. Repeat the same process without `LOG_LEVEL` defined, and you should see things log at the `info` level.