### PR TITLE
hotfix/orange-893-ssl-for-db-migration

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -17,6 +17,7 @@ if (postgres.sslEnabled) {
       config.dialectOptions = {
           ssl: {
               ca: postgres.sslCaCert,
+              rejectUnauthorized: true
           },
       };
   }

--- a/config/database.js
+++ b/config/database.js
@@ -1,6 +1,8 @@
+const Sequelize = require('sequelize');
+const logger = require('./winston');
 const postgres = require('./config.js').postgres;
 
-let config = {
+const config = {
     username: postgres.user,
     password: postgres.password,
     database: postgres.db,
@@ -12,15 +14,26 @@ let config = {
 };
 
 if (postgres.sslEnabled) {
-  config.ssl = postgres.sslEnabled;
-  if (postgres.sslCaCert) {
-      config.dialectOptions = {
-          ssl: {
-              ca: postgres.sslCaCert,
-              rejectUnauthorized: true
-          },
-      };
-  }
+    config.ssl = postgres.sslEnabled;
+    if (postgres.sslCaCert) {
+        config.dialectOptions = {
+            ssl: {
+                ca: postgres.sslCaCert,
+                rejectUnauthorized: true,
+            },
+        };
+    }
+}
+
+// TODO ARH: This sequelize instance, using the config defined in this file,
+// exists only to check if this config results an a properly encrypted connection to Postgres.
+// The proper way to do it is to consolidate sequelize.js and database.js (this file) such that
+// they use the same sequelize instance. This is documented in ORANGE-897.
+const sequelize = new Sequelize(config);
+
+if (postgres.sslEnabled) {
+    // eslint-disable-next-line no-use-before-define
+    ensureConnectionIsEncrypted(sequelize);
 }
 
 module.exports = {
@@ -28,3 +41,24 @@ module.exports = {
     test: config,
     production: config,
 };
+
+// TODO ARH: This is defined both in sequelize.js and here because sequelize.js uses import/export,
+// which requires bable, which does not work in this file. This needs to be deduplicated.
+// This is documented in ORANGE-897.
+// eslint-disable-next-line no-shadow
+function ensureConnectionIsEncrypted(sequelize) {
+    sequelize.query('select 1 as "dummy string"', {
+        type: sequelize.QueryTypes.SELECT,
+    })
+    .then((result) => {
+        logger.info('Sequelize is not throwing SSL-related errors, so we assume SSL is configured correctly.');
+    })
+    .catch((err) => {
+        if (err.message === 'self signed certificate in certificate chain') {
+            logger.error(`Sequelize is throwing error "${err.message}", which it does seemingly any time the certificate is invalid. Ensure your MESSAGING_SERVICE_PG_CA_CERT is set correctly.`);
+        } else {
+            logger.error(`Error attempting to verify the sequelize connection is SSL encrypted: ${err.message}`);
+        }
+        process.exit(1);
+  });
+}

--- a/config/database.js
+++ b/config/database.js
@@ -1,14 +1,26 @@
 const postgres = require('./config.js').postgres;
 
-const config = {
+let config = {
     username: postgres.user,
     password: postgres.password,
     database: postgres.db,
     host: postgres.host,
+    port: postgres.port,
     dialect: 'postgres',
     migrationStorageTableName: 'sequelize_meta',
     logging: true,
 };
+
+if (postgres.sslEnabled) {
+  config.ssl = postgres.sslEnabled;
+  if (postgres.sslCaCert) {
+      config.dialectOptions = {
+          ssl: {
+              ca: postgres.sslCaCert,
+          },
+      };
+  }
+}
 
 module.exports = {
     development: config,

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -25,6 +25,7 @@ if (config.postgres.sslEnabled) {
         sequelizeOptions.dialectOptions = {
             ssl: {
                 ca: config.postgres.sslCaCert,
+                rejectUnauthorized: true
             },
         };
     }

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -25,7 +25,7 @@ if (config.postgres.sslEnabled) {
         sequelizeOptions.dialectOptions = {
             ssl: {
                 ca: config.postgres.sslCaCert,
-                rejectUnauthorized: true
+                rejectUnauthorized: true,
             },
         };
     }
@@ -37,6 +37,11 @@ const sequelize = new Sequelize(
     config.postgres.password,
     sequelizeOptions
 );
+
+if (config.postgres.sslEnabled) {
+    // eslint-disable-next-line no-use-before-define
+    ensureConnectionIsEncrypted(sequelize);
+}
 
 const Message = sequelize.import('../server/models/message.model');
 const User = sequelize.import('../server/models/user.model');
@@ -72,4 +77,24 @@ db.UserThread = UserThread;
 module.exports = _.extend({
     sequelize,
     Sequelize,
+    // eslint-disable-next-line no-use-before-define
+    ensureConnectionIsEncrypted,
 }, db);
+
+// eslint-disable-next-line no-shadow
+function ensureConnectionIsEncrypted(sequelize) {
+    sequelize.query('select 1 as "dummy string"', {
+        type: sequelize.QueryTypes.SELECT,
+    })
+    .then((result) => {
+        logger.info('Sequelize is not throwing SSL-related errors, so we assume SSL is configured correctly.');
+    })
+    .catch((err) => {
+        if (err.message === 'self signed certificate in certificate chain') {
+            logger.error(`Sequelize is throwing error "${err.message}", which it does seemingly any time the certificate is invalid. Ensure your MESSAGING_SERVICE_PG_CA_CERT is set correctly.`);
+        } else {
+            logger.error(`Error attempting to verify the sequelize connection is SSL encrypted: ${err.message}`);
+        }
+        process.exit(1);
+  });
+}

--- a/config/winston.js
+++ b/config/winston.js
@@ -1,4 +1,4 @@
-import config from './config';
+const config = require('./config');
 
 const { createLogger, transports, format } = require('winston');
 
@@ -21,4 +21,4 @@ if (config.env !== 'production') {
     );
 }
 
-export default logger;
+module.exports = logger;


### PR DESCRIPTION
# What does this PR do?
Two things:
1. Encrypts the connection between Node.js and Postgres when running the DB migration.

2. 
(Both when running the server and when running the migration...)
When `MESSAGING_SERVICE_PG_SSL_ENABLED=true`, it causes sequelize to check to ensure that the connection to postgres is encrypted. It logs an info message if successful, and an error message if not.

# Related JIRA tickets:
https://jira.amida.com/browse/ORANGE-893

# How should this be manually tested?

## Case A: `MESSAGING_SERVICE_PG_SSL_ENABLED=false`:

(Both when running the server and when running the migration...)
When `MESSAGING_SERVICE_PG_SSL_ENABLED=false`, no messages about the encrypted state of the connection will be logged, and everything (e.g. `yarn start`, `yarn migrate`, `yarn migrate:undo`) should just work as expected.

## Case B:  `MESSAGING_SERVICE_PG_SSL_ENABLED=true` and `MESSAGING_SERVICE_PG_CA_CERT` is configured correctly and Your postgres DB has the "sslinfo" extension installed:

> The migration installs the "sslinfo" extension automatically, so this should just work. Also, you should never run the server without first running the migration, so this should also just work. See case D for what should happen "sslinfo" is not installed.

(Both when running the server and when running the migration...)
Set `MESSAGING_SERVICE_PG_SSL_ENABLED=true`, and configure `MESSAGING_SERVICE_PG_CA_CERT` correctly (see following info).

> The easiest way to get a correct SSL cert when using Postgres running on RDS is:
> Download the RDS standard cert from here: https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem).
> (For more info about this cert, see this: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html )

Now that you have the cert...

Since `MESSAGING_SERVICE_PG_CA_CERT` is supposed to equal the cert itself, not the path to the cert, and since `nodeenv` / `.env` choke on this, the easiest way to set `MESSAGING_SERVICE_PG_CA_CERT` is to do it on the command line with your command, for example like this:

```sh
MESSAGING_SERVICE_PG_CA_CERT=$(cat /path/to/your/downloaded/rds-combined-ca-bundle.pem) THE_COMMAND
```
where THE_COMMAND would be `yarn start`, `yarn migrate`, or `yarn migrate:undo`

Expected outcome:

You should see an info message saying:
```sh
info: sequelize select ssl_is_used() is reporting: true (Note: 'true' means the connection is encrypted.)
```
And whatever THE_COMMAND was, it should run successfully.

## Case C: `MESSAGING_SERVICE_PG_SSL_ENABLED=true` and `MESSAGING_SERVICE_PG_CA_CERT` is configured correctly, but the "sslinfo" extension is _NOT_ installed.

1. Drop your messaging DB and re-create it. (this deletes the extension)
2. Don't run the migration (because doing so would create the extension)
3. Run the server:
```
MESSAGING_SERVICE_PG_CA_CERT=$(cat /path/to/your/downloaded/rds-combined-ca-bundle.pem) yarn start
```
You should see this error message:

> Sequelize is throwing error "$function ssl_is_used() does not exist". This happens when your messaging PG DB does not have extension "ssl info" installed.


## Case D: `MESSAGING_SERVICE_PG_SSL_ENABLED=true` but the cert is configured incorrectly.

1. Set `MESSAGING_SERVICE_PG_CA_CERT` to anything that is invalid.
2. `yarn start`

You should see this error message:

> `Sequelize is throwing error "self signed certificate in certificate chain", which it does seemingly any time the certificate is invalid. Ensure your MESSAGING_SERVICE_PG_CA_CERT is set correctly.`
