### PR TITLE
removing filter by loguser on index threads

### DIFF
--- a/server/controllers/threads.controller.js
+++ b/server/controllers/threads.controller.js
@@ -272,7 +272,7 @@ function index(req, res, next) {
     const { logUsername } = req.query;
 
     if (username === logUsername) {
-        sequelize.query('SELECT * FROM "Users" as A inner join "UserThreads" as UserThread on A."id" = UserThread."UserId" inner join "Threads" as E on UserThread."ThreadId" = E."id" and (E."logUserId" = A."id" OR E."logUserId" is null ) inner join "Messages" as LastMessage on E."lastMessageId" = LastMessage."id" Where A.username = :username Order By "lastMessageSent" DESC',
+        sequelize.query('SELECT * FROM "Users" as A inner join "UserThreads" as UserThread on A."id" = UserThread."UserId" inner join "Threads" as E on UserThread."ThreadId" = E."id" inner join "Messages" as LastMessage on E."lastMessageId" = LastMessage."id" Where A.username = :username Order By "lastMessageSent" DESC',
             { replacements: { username }, type: sequelize.QueryTypes.SELECT }
         ).then((logData) => {
             if (!logData) {


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
- This PR removes the filtering of threads by `logUserId` in our threads.index function call. We no longer needed this filtering because both the mobile client and the web client were only sending messages from their default patient / logs
#### Related JIRA tickets:
#### How should this be manually tested?
Send messages from your mobile client to your web client. Check that the message shows up in the web client. 
#### Any background context you want to provide?
#### Screenshots (if appropriate):